### PR TITLE
Allow configuring resizing configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ bucket.
 
 ``ROUTE_PREFIX``: Path prefix for serving the photo backend API. 
 
+``RESIZING_CONFIG``: Configuration of the thumbnail names and sizes serialized in JSON. See c2corg\_images/__init__.py for a description of the format. 
+
 Here is an example configuration with S3 backend on exoscale:
 
 ```

--- a/c2corg_images/__init__.py
+++ b/c2corg_images/__init__.py
@@ -2,18 +2,25 @@ from pyramid.config import Configurator
 from pyramid.renderers import JSON
 from pyramid.events import NewRequest
 import os
+import json
 
-RESIZING_CONFIG = [
-    {'suffix': 'BI', 'convert': ['-resize', '1500x1500>',
-                                 '-quality', '90']},
-    {'suffix': 'MI', 'convert': ['-resize', '400x400>',
-                                 '-quality', '90']},
-    {'suffix': 'SI', 'convert': ['-resize', '200x200^',
-                                 '-gravity', 'center',
-                                 '-extent', '200x200',
-                                 '-quality', '90']}
-]
+def parse_resizing_config(serialized_config):
+    if serialized_config is not None:
+        return json.loads(serialized_config)
+    else:
+        # See documentation at http://www.imagemagick.org/Usage/resize
+        return [
+                    {'suffix': 'BI', 'convert': ['-resize', '1500x1500>',
+                                                 '-quality', '90']},
+                    {'suffix': 'MI', 'convert': ['-resize', '400x400>',
+                                                 '-quality', '90']},
+                    {'suffix': 'SI', 'convert': ['-resize', '200x200^',
+                                                 '-gravity', 'center',
+                                                 '-extent', '200x200',
+                                                 '-quality', '90']}
+               ]
 
+RESIZING_CONFIG = parse_resizing_config(os.environ.get('RESIZING_CONFIG', None))
 
 def add_cors_headers_response_callback(event):
     def cors_headers(request, response):

--- a/tests/inside/test_init.py
+++ b/tests/inside/test_init.py
@@ -1,0 +1,21 @@
+from c2corg_images import parse_resizing_config, RESIZING_CONFIG
+
+import json
+
+
+def test_resizing_config_from_environment():
+    resizing_config = [
+        {'suffix': 'master', 'convert': ['-resize', '2048x2048>', '-quality', '90']},
+        {'suffix': 'L', 'convert': ['-resize', '780x487>', '-quality', '90']},
+        {'suffix': 'M', 'convert': ['-resize', '268x168>', '-quality', '90']},
+        {'suffix': 'S', 'convert': ['-resize', '170x106>', '-quality', '90']},
+        {'suffix': 'XS', 'convert': ['-resize', '78x78>', '-quality', '90']}
+    ]
+    serialized = json.dumps(resizing_config)
+    parsed = parse_resizing_config(serialized)
+    assert parsed == resizing_config
+
+
+def test_resizing_config_from_default():
+    parsed = parse_resizing_config(None)
+    assert parsed == RESIZING_CONFIG


### PR DESCRIPTION
Pass a JSON serialized config as the RESIZING_CONFIG environment variable.

Example in docker-compose:
```bash
RESIZING_CONFIG: '[{"convert": ["-resize", "2048x2048>", "-quality", "90"], "suffix": "master"}, {"convert": ["-resize", "780x487>", "-quality", "90"], "suffix": "L"}, {"convert": ["-resize", "268x168>", "-quality", "90"], "suffix": "M"}, {"convert": ["-resize", "170x106>", "-quality", "90"], "suffix": "S"}, {"convert": ["-resize", "78x78>", "-quality", "90"], "suffix": "XS"}]'
```