### PR TITLE
Hotfix format issue

### DIFF
--- a/c2corg_images/views.py
+++ b/c2corg_images/views.py
@@ -76,7 +76,7 @@ def upload(request):
         kind = get_format(raw_file, request.POST['file'].filename)
         log.debug('%s - detected format is %s', pre_key, kind)
     except:
-        raise HTTPBadRequest('Bad format for %s', output_file)
+        raise HTTPBadRequest('Bad format for %s' % request.POST['file'].filename)
 
     if kind == 'JPEG':
         kind = 'jpg'


### PR DESCRIPTION
```
photo_1      | [2017-09-06 08:58:43 +0000] [21] [ERROR] Error handling request /photo/upload
photo_1      | Traceback (most recent call last):
photo_1      |   File "/var/www/c2corg_images/views.py", line 76, in upload
photo_1      |     kind = get_format(raw_file, request.POST['file'].filename)
photo_1      |   File "/var/www/c2corg_images/views.py", line 31, in get_format
photo_1      |     with Image(filename=path) as image:
photo_1      |   File "/usr/lib/python3/dist-packages/wand/image.py", line 1985, in __init__
photo_1      |     self.read(filename=filename, resolution=resolution)
photo_1      |   File "/usr/lib/python3/dist-packages/wand/image.py", line 2042, in read
photo_1      |     self.raise_exception()
photo_1      |   File "/usr/lib/python3/dist-packages/wand/resource.py", line 218, in raise_exception
photo_1      |     raise e
photo_1      | wand.exceptions.MissingDelegateError: b"no decode delegate for this image format `' @ error/constitute.c/ReadImage/501"
photo_1      |
photo_1      | During handling of the above exception, another exception occurred:
photo_1      |
photo_1      | Traceback (most recent call last):
photo_1      |   File "/usr/local/lib/python3.4/dist-packages/gunicorn/workers/sync.py", line 135, in handle
photo_1      |     self.handle_request(listener, req, client, addr)
photo_1      |   File "/usr/local/lib/python3.4/dist-packages/gunicorn/workers/sync.py", line 176, in handle_request
photo_1      |     respiter = self.wsgi(environ, resp.start_response)
photo_1      |   File "/usr/local/lib/python3.4/dist-packages/pyramid/router.py", line 223, in __call__
photo_1      |     response = self.invoke_subrequest(request, use_tweens=True)
photo_1      |   File "/usr/local/lib/python3.4/dist-packages/pyramid/router.py", line 198, in invoke_subrequest
photo_1      |     response = handle_request(request)
photo_1      |   File "/usr/local/lib/python3.4/dist-packages/pyramid/tweens.py", line 20, in excview_tween
photo_1      |     response = handler(request)
photo_1      |   File "/usr/local/lib/python3.4/dist-packages/pyramid/router.py", line 145, in handle_request
photo_1      |     view_name
photo_1      |   File "/usr/local/lib/python3.4/dist-packages/pyramid/view.py", line 541, in _call_view
photo_1      |     response = view_callable(context, request)
photo_1      |   File "/usr/local/lib/python3.4/dist-packages/pyramid/config/views.py", line 602, in __call__
photo_1      |     return view(context, request)
photo_1      |   File "/usr/local/lib/python3.4/dist-packages/pyramid/config/views.py", line 353, in rendered_view
photo_1      |     result = view(context, request)
photo_1      |   File "/usr/local/lib/python3.4/dist-packages/pyramid/config/views.py", line 507, in _requestonly_view
photo_1      |     response = view(request)
photo_1      |   File "/var/www/c2corg_images/views.py", line 79, in upload
photo_1      |     raise HTTPBadRequest('Bad format for %s', output_file)
photo_1      |   File "/usr/local/lib/python3.4/dist-packages/pyramid/httpexceptions.py", line 223, in __init__
photo_1      |     self.headers.extend(headers)
photo_1      |   File "/usr/local/lib/python3.4/dist-packages/webob/multidict.py", line 233, in extend
photo_1      |     for k, v in other:
photo_1      | ValueError: I/O operation on closed file.
```

https://docs.pylonsproject.org/projects/pyramid/en/latest/api/httpexceptions.html#pyramid.httpexceptions.HTTPException