### PR TITLE
Fix potential loss of original photos

### DIFF
--- a/c2corg_images/views.py
+++ b/c2corg_images/views.py
@@ -149,7 +149,7 @@ def recrop(request):
     # Retrieve and rename file
     old_filename = request.POST['filename']
     base, ext = os.path.splitext(old_filename)
-    active_storage.move(old_filename, temp_storage)
+    active_storage.copy(old_filename, temp_storage)
     filename = '{name}{ext}'.format(name=create_pseudo_unique_key(), ext=ext)
     os.rename(temp_storage.object_path(old_filename), temp_storage.object_path(filename))
     temp_storage.copy(filename, active_storage)


### PR DESCRIPTION
We are missing some original photos in S3. If there is a problem in the
middle of recropping, we can potentially loose original photos.